### PR TITLE
fix double fire OnEntityCreated void in CLeap_OnTouch hooks of jockey fixes

### DIFF
--- a/addons/sourcemod/scripting/l4d2_jockey_jumpcap_patch.sp
+++ b/addons/sourcemod/scripting/l4d2_jockey_jumpcap_patch.sp
@@ -22,7 +22,6 @@ public OnPluginStart()
 {
 	hCLeap_OnTouch = DHookCreate(CLEAP_ONTOUCH_OFFSET, HookType_Entity, ReturnType_Void, ThisPointer_CBaseEntity, CLeap_OnTouch);
 	DHookAddParam(hCLeap_OnTouch, HookParamType_CBaseEntity);
-	DHookAddEntityListener(ListenType_Created, OnEntityCreated);
 	
 	HookEvent("round_start", EventHook:OnRoundStart, EventHookMode_PostNoCopy);
 	HookEvent("player_shoved", OnPlayerShoved);

--- a/addons/sourcemod/scripting/l4d2_jockeyed_charger_fix.sp
+++ b/addons/sourcemod/scripting/l4d2_jockeyed_charger_fix.sp
@@ -18,7 +18,6 @@ public OnPluginStart()
 {
 	hCLeap_OnTouch = DHookCreate(CLEAP_ONTOUCH_OFFSET, HookType_Entity, ReturnType_Void, ThisPointer_CBaseEntity, CLeap_OnTouch);
 	DHookAddParam(hCLeap_OnTouch, HookParamType_CBaseEntity);
-	DHookAddEntityListener(ListenType_Created, OnEntityCreated);
 }
 
 public OnEntityCreated(entity, const String:classname[])


### PR DESCRIPTION
this because after sourcemod 1.5 sdkhooks built in sourcemod and void OnEntityCreated called by default

Signed-off-by: electr0w <electroshoc.m@gmail.com>