### PR TITLE
A fixes some incorrect code around plugins used player_hurt event hooks

### DIFF
--- a/addons/sourcemod/scripting/double_getup.sp
+++ b/addons/sourcemod/scripting/double_getup.sp
@@ -245,38 +245,40 @@ public player_revive(Handle:event, const String:name[], bool:dontBroadcast) {
 }
 
 // A catch-all to handle damage that is not associated with an event. I use this instead of player_hurt because it ignores godframes.
-public Action:OnTakeDamage(victim, &attacker, &inflictor, &Float:damage, &damagetype) {
+public Action:OnTakeDamage(victim, &attacker, &inflictor, &Float:damage, &damagetype) 
+{
     new SurvivorCharacter:survivor = IdentifySurvivor(victim);
-    if (survivor == SC_NONE) return;
-    decl String:weapon[32];
-    GetEdictClassname(inflictor, weapon, sizeof(weapon));
-    if (strcmp(weapon, "weapon_tank_claw") == 0) {
-        if (playerState[survivor] == PlayerState:CHARGER_GETUP) {
-            interrupt[survivor] = true;
-        } else if (playerState[survivor] == PlayerState:MULTI_CHARGED) {
-            pendingGetups[survivor]++;
-        }
+    if (survivor != SC_NONE)
+	{
+		decl String:weapon[32];
+		GetEdictClassname(inflictor, weapon, sizeof(weapon));
+		if (strcmp(weapon, "weapon_tank_claw") == 0) {
+			if (playerState[survivor] == PlayerState:CHARGER_GETUP) {
+				interrupt[survivor] = true;
+			} else if (playerState[survivor] == PlayerState:MULTI_CHARGED) {
+				pendingGetups[survivor]++;
+			}
 
-        if (playerState[survivor] == PlayerState:TANK_ROCK_GETUP && GetConVarBool(rockPunchFix)) {
-            playerState[survivor] = PlayerState:TANK_PUNCH_FIX;
-        } else if (playerState[survivor] == PlayerState:JOCKEYED) {
-            playerState[survivor] = PlayerState:TANK_PUNCH_JOCKEY_FIX;
-            _TankLandTimer(victim);
-        } else {
-            playerState[survivor] = PlayerState:TANK_PUNCH_FLY;
-            // Watches and waits for the survivor to enter their getup animation. It is possible to skip the fly animation, so this can't be tracked by state-based logic.
-            _TankLandTimer(victim);
-        }
-    } else if (strcmp(weapon, "tank_rock") == 0) {
-        if (playerState[survivor] == PlayerState:CHARGER_GETUP) {
-            interrupt[survivor] = true;
-        } else if (playerState[survivor] == PlayerState:MULTI_CHARGED) {
-            pendingGetups[survivor]++;
-        }
-        playerState[survivor] = PlayerState:TANK_ROCK_GETUP;
-        _GetupTimer(victim);
-    }
-    return;
+			if (playerState[survivor] == PlayerState:TANK_ROCK_GETUP && GetConVarBool(rockPunchFix)) {
+				playerState[survivor] = PlayerState:TANK_PUNCH_FIX;
+			} else if (playerState[survivor] == PlayerState:JOCKEYED) {
+				playerState[survivor] = PlayerState:TANK_PUNCH_JOCKEY_FIX;
+				_TankLandTimer(victim);
+			} else {
+				playerState[survivor] = PlayerState:TANK_PUNCH_FLY;
+				// Watches and waits for the survivor to enter their getup animation. It is possible to skip the fly animation, so this can't be tracked by state-based logic.
+				_TankLandTimer(victim);
+			}
+		} else if (strcmp(weapon, "tank_rock") == 0) {
+			if (playerState[survivor] == PlayerState:CHARGER_GETUP) {
+				interrupt[survivor] = true;
+			} else if (playerState[survivor] == PlayerState:MULTI_CHARGED) {
+				pendingGetups[survivor]++;
+			}
+			playerState[survivor] = PlayerState:TANK_ROCK_GETUP;
+			_GetupTimer(victim);
+		}
+	}
 }
 
 // Detects when a player lands from a tank punch.

--- a/addons/sourcemod/scripting/l4d2_melee_fix.sp
+++ b/addons/sourcemod/scripting/l4d2_melee_fix.sp
@@ -40,9 +40,7 @@ public Action:PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast)
 
 bool:IsSi(client) 
 {
-    if (IsClientConnected(client)
-    && IsClientInGame(client)
-    && GetClientTeam(client) == 3) 
+    if (client > 0 && client <= MaxClients && IsClientInGame(client) && GetClientTeam(client) == 3) 
     {
         return true;
     }

--- a/addons/sourcemod/scripting/l4d2_melee_shenanigans.sp
+++ b/addons/sourcemod/scripting/l4d2_melee_shenanigans.sp
@@ -15,7 +15,7 @@
 new lastAnimSequence[MAXPLAYERS + 1];
 //Should initialise array as all false
 new bool:giveWeapon[MAXPLAYERS + 1];             
-new 	i = 0;
+new iTick = 0;
 
 public Plugin:myinfo =
 {
@@ -39,46 +39,44 @@ public Action:PlayerHit(Handle:event, String:event_name[], bool:dontBroadcast)
     if (IsSurvivor(PlayerID) && StrEqual(Weapon, "tank_claw"))
     {
         new activeweapon = GetEntPropEnt(PlayerID, Prop_Send, "m_hActiveWeapon");
-        if (!IsValidEdict(activeweapon)) return;
- 
-        decl String:weaponname[64];
-        GetEdictClassname(activeweapon, weaponname, sizeof(weaponname));
-        if (!StrEqual(weaponname, "weapon_melee", false)) return;		
-		if (GetPlayerWeaponSlot(PlayerID, 0) != -1)
+        if (IsValidEdict(activeweapon))
 		{
-			SDKHook(PlayerID, SDKHook_PostThink, OnThink);
+			decl String:weaponname[64];
+			GetEdictClassname(activeweapon, weaponname, sizeof(weaponname));	
+			
+			if (StrEqual(weaponname, "weapon_melee", false) && GetPlayerWeaponSlot(PlayerID, 0) != -1)
+			{
+				SDKHook(PlayerID, SDKHook_PostThink, OnThink);
+			}
 		}
-		return;
-		
-		
     }
 }
 
 public OnThink(client)
 {
-	if(i > 300)
-		{ 
-		i = 0;
+	if(iTick > 300)
+	{ 
+		iTick = 0;
 		SDKUnhook(client, SDKHook_PostThink, OnThink);
+	}
+	iTick = 1 + iTick;
+
+	new sequence = GetEntProp(client, Prop_Send, "m_nSequence");
+
+	if (!giveWeapon[client])
+	{
+		if ((lastAnimSequence[client] == SEQ_COACH_NICK && sequence != SEQ_COACH_NICK) || (lastAnimSequence[client] == SEQ_ELLIS && sequence != SEQ_ELLIS) || (lastAnimSequence[client] == SEQ_ROCHELLE   && sequence != SEQ_ROCHELLE)|| (lastAnimSequence[client] == SEQ_BILL_LOUIS   && sequence != SEQ_BILL_LOUIS)|| (lastAnimSequence[client] == SEQ_FRANCIS   && sequence != SEQ_FRANCIS)|| (lastAnimSequence[client] == SEQ_ZOEY   && sequence != SEQ_ZOEY))
+		{
+			giveWeapon[client] = true;
 		}
-	i = 1 + i;
-	
-    new sequence = GetEntProp(client, Prop_Send, "m_nSequence");
-    
-    if (!giveWeapon[client])
-    {
-        if ((lastAnimSequence[client] == SEQ_COACH_NICK && sequence != SEQ_COACH_NICK) || (lastAnimSequence[client] == SEQ_ELLIS && sequence != SEQ_ELLIS) || (lastAnimSequence[client] == SEQ_ROCHELLE   && sequence != SEQ_ROCHELLE)|| (lastAnimSequence[client] == SEQ_BILL_LOUIS   && sequence != SEQ_BILL_LOUIS)|| (lastAnimSequence[client] == SEQ_FRANCIS   && sequence != SEQ_FRANCIS)|| (lastAnimSequence[client] == SEQ_ZOEY   && sequence != SEQ_ZOEY))
-        {
-            giveWeapon[client] = true;
-        }
-    }
-    else
-    {
-        SwapToGun(client)
-        giveWeapon[client] = false;
-		i = 0;
-        SDKUnhook(client, SDKHook_PostThink, OnThink);
-    }
+	}
+	else
+	{
+		SwapToGun(client)
+		giveWeapon[client] = false;
+		iTick = 0;
+		SDKUnhook(client, SDKHook_PostThink, OnThink);
+	}
 	lastAnimSequence[client] = sequence;
 }
 

--- a/addons/sourcemod/scripting/l4d2_nosey_parker.sp
+++ b/addons/sourcemod/scripting/l4d2_nosey_parker.sp
@@ -58,17 +58,17 @@ public OnConfigsExecuted()
     fGhostDelay = GetConVarFloat(FindConVar("z_ghost_delay_min"));
 }
 
-public Event_PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast)
+public Action:Event_PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast)
 {
     new victim = GetClientOfUserId(GetEventInt(event, "userid"));
-    if (!IsInfected(victim) || IsTargetedSi(victim) < 0)
-        return;
-
-    new attacker = GetClientOfUserId(GetEventInt(event, "attacker"));
-    if (attacker == 0 || !IsClientInGame(attacker) || !IsSurvivor(attacker) || IsFakeClient(attacker) || !IsPlayerAlive(attacker))
-        return;
-
-    iDamage[attacker][victim] += GetEventInt(event, "dmg_health");
+    if (IsInfected(victim) && IsTargetedSi(victim) > 0)
+	{
+		new attacker = GetClientOfUserId(GetEventInt(event, "attacker"));
+		if (attacker > 0 && IsClientInGame(attacker) && IsSurvivor(attacker) && !IsFakeClient(attacker) && IsPlayerAlive(attacker))
+		{
+			iDamage[attacker][victim] += GetEventInt(event, "dmg_health");
+		}
+	}
 }
 
 public Action:Event_PlayerDeath(Handle:event, const String:name[], bool:dontBroadcast)

--- a/addons/sourcemod/scripting/l4d2_slowdown_control.sp
+++ b/addons/sourcemod/scripting/l4d2_slowdown_control.sp
@@ -93,19 +93,19 @@ public OnPluginStart()
 	HookEvent("round_end", RoundEnd);
 }
 
-public TankSpawn(Handle:event, const String:name[], bool:dontBroadcast) 
+public Action: TankSpawn(Handle:event, const String:name[], bool:dontBroadcast) 
 {
-	if (tankInPlay) 
-		return;
-		
-	tankInPlay = true;
-	if (GetConVarFloat(hCvarSdInwaterDuringTank) > 0.0) 
+	if (!tankInPlay) 
 	{
-		PrintToChatAll("\x05Water Slowdown\x01 has been reduced while Tank is in play.");
+		tankInPlay = true;
+		if (GetConVarFloat(hCvarSdInwaterDuringTank) > 0.0) 
+		{
+			PrintToChatAll("\x05Water Slowdown\x01 has been reduced while Tank is in play.");
+		}
 	}
 }
 
-public TankDeath(Handle:event, const String:name[], bool:dontBroadcast) 
+public Action: TankDeath(Handle:event, const String:name[], bool:dontBroadcast) 
 {
 	new client = GetClientOfUserId(GetEventInt(event, "userid"));
 	if (IsInfected(client) && IsTank(client)) 
@@ -118,7 +118,7 @@ public TankDeath(Handle:event, const String:name[], bool:dontBroadcast)
 	}
 }
 
-public RoundEnd(Handle:event, const String:name[], bool:dontBroadcast) 
+public Action: RoundEnd(Handle:event, const String:name[], bool:dontBroadcast) 
 {
 	tankInPlay = false;
 }
@@ -129,27 +129,27 @@ public RoundEnd(Handle:event, const String:name[], bool:dontBroadcast)
  *
 **/
 
-public PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast) 
+public Action: PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast) 
 {
 	new client = GetClientOfUserId(GetEventInt(event, "userid"));
-	if (!IsInfected(client)) 
-		return;
-
-	new Float:slowdown = IsTank(client) ? GetActualValue(hCvarSdGunfireTank) : GetActualValue(hCvarSdGunfireSi);
-	if (slowdown == 1.0)
+	if (IsInfected(client)) 
 	{
-		ApplySlowdown(client, slowdown);
-	}
-	else if (slowdown > 0.0)
-	{
-		new damage = GetEventInt(event, "dmg_health");
-		decl String:weapon[64];
-		GetEventString(event, "weapon", weapon, sizeof(weapon));
+		new Float:slowdown = IsTank(client) ? GetActualValue(hCvarSdGunfireTank) : GetActualValue(hCvarSdGunfireSi);
+		if (slowdown == 1.0)
+		{
+			ApplySlowdown(client, slowdown);
+		}
+		else if (slowdown > 0.0)
+		{
+			new damage = GetEventInt(event, "dmg_health");
+			decl String:weapon[64];
+			GetEventString(event, "weapon", weapon, sizeof(weapon));
 
-		decl Float:scale;
-		decl Float:modifier;
-		GetScaleAndModifier(scale, modifier, weapon, damage);
-		ApplySlowdown(client, 1 - modifier * scale * slowdown);
+			decl Float:scale;
+			decl Float:modifier;
+			GetScaleAndModifier(scale, modifier, weapon, damage);
+			ApplySlowdown(client, 1 - modifier * scale * slowdown);
+		}
 	}
 }
 

--- a/addons/sourcemod/scripting/l4d2_sound_manipulation.sp
+++ b/addons/sourcemod/scripting/l4d2_sound_manipulation.sp
@@ -169,9 +169,9 @@ public Action:PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast)
 	if (StrEqual(weapon, "melee") && IsSi(victim))
 	{
 		// SI Died
-		if (health <= 0 && GetConVarBool(cSurvivorMelee))
+		if (health <= 0 && GetConVarBool(cSurvivorMelee)
+		&& attacker > 0 && attacker <= MaxClients)
 		{
-			if (attacker <= 0 || attacker > MaxClients) return Plugin_Handled;
 			new String:clientModel[42];
 			GetClientModel(attacker, clientModel, sizeof(clientModel));
 			
@@ -203,8 +203,6 @@ public Action:PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast)
 				new rndPick = GetRandomInt(0, MAX_ELLISSOUND);
 				EmitSoundToAll(sEllisSound[rndPick], attacker, SNDCHAN_VOICE);
 			}
-			//No Matching Survivors
-			else return Plugin_Continue;
 				
 			//L4D1 Survivor.. No Files yet
 			//else if (StrEqual(clientModel, "models/survivors/survivor_manager.mdl")) 
@@ -213,7 +211,6 @@ public Action:PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast)
 			//else if (StrEqual(clientModel, "models/survivors/survivor_biker.mdl"))
 		}    
 	}
-	return Plugin_Continue;
 }	
 
 bool:IsSi(client) 

--- a/addons/sourcemod/scripting/si_fire_immunity.sp
+++ b/addons/sourcemod/scripting/si_fire_immunity.sp
@@ -29,27 +29,24 @@ public OnMapStart()
 	}
 }
 
-public SIOnFire(Handle:event, const String:name[], bool:dontBroadcast)
+public Action:SIOnFire(Handle:event, const String:name[], bool:dontBroadcast)
 {
-    
     new client = GetClientOfUserId(GetEventInt(event, "userid"));
-    if(!IsValidClient(client) || !(GetClientTeam(client) == 3)) return;
-    
-    new dmgtype = GetEventInt(event,"type");
-    if(dmgtype != 8) return;
-	
-    if(GetEntProp(client, Prop_Send, "m_zombieClass") == 8) ExtinguishEntity(client);
+    if(IsValidClient(client) && (GetClientTeam(client) == 3) && GetEventInt(event,"type") == 8)
+	{
+		if(GetEntProp(client, Prop_Send, "m_zombieClass") == 8) ExtinguishEntity(client);
 
-    if(GetConVarInt(infected_fire_immunity) == 3) CreateTimer(1.0, Extinguish, client);
+		if(GetConVarInt(infected_fire_immunity) == 3) CreateTimer(1.0, Extinguish, client);
 
-    if(GetConVarInt(infected_fire_immunity) <= 2) ExtinguishEntity(client);
-    
-    if(GetConVarInt(infected_fire_immunity) == 1)
-    {
-        new CurHealth = GetClientHealth(client);
-        new DmgDone	= GetEventInt(event,"dmg_health");
-        SetEntityHealth(client,(CurHealth + DmgDone));
-    }
+		if(GetConVarInt(infected_fire_immunity) <= 2) ExtinguishEntity(client);
+		
+		if(GetConVarInt(infected_fire_immunity) == 1)
+		{
+			new CurHealth = GetClientHealth(client);
+			new DmgDone	= GetEventInt(event,"dmg_health");
+			SetEntityHealth(client,(CurHealth + DmgDone));
+		}
+	}
 }
  
 public Action:Extinguish(Handle:timer, any:client)


### PR DESCRIPTION
I have server on  SM 1.7, and got crash https://crash.limetech.org/h372ttedqwvo in config Hunters 2x2 from promod very same as https://www.l4dnation.com/server-zone/segmentation-faults-again/msg43563/#msg43563 posted in 2015.

I use plugins in folder /optional from a last eq3.0. After look code in this repository for plugins loaded in config Hunters 2x2 and have "player_hurt" event hook with a hook parameter EventHookMode_Post. I see some incorect code.

What i change:
1. fixed missing "Action:" in event callback bodies.
2. removed "return;" logic where this not need, and where possible can cause random crashes (after return operation in event callback) on new version of SM 1.7.X and newest (see https://www.l4dnation.com/server-zone/segmentation-faults-again/msg43563/#msg43563), i think this by old compilied versions of plugins have a incorrect a callback body format in together with waste "return;" operations not needed in cases what i fixed, this should be fix automaticaly by code interpretator of SM but in some situations.. may be some wrong..)
3. optimized some checks (for example IsClientConnected(client)	 before IsClientInGame(client) now not need, this included in IsClientInGame(client)  after 1.5 or 1.6 sm)
4. fixed compilier errors in l4d2_melee_shenanigans.sp where used global "i" var a declared in includes of core sourcemod, i just renamed this variable to iTick.

Signed-off-by: electr0w <electroshoc.m@gmail.com>
