### PR TITLE
Some changes for l4d2_melee_fix and double_getup

### DIFF
--- a/addons/sourcemod/scripting/double_getup.sp
+++ b/addons/sourcemod/scripting/double_getup.sp
@@ -140,8 +140,8 @@ public round_start(Handle:event, const String:name[], bool:dontBroadcast) {
 public smoker_land(Handle:event, const String:name[], bool:dontBroadcast) {
     new client = GetClientOfUserId(GetEventInt(event, "victim"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor == SC_NONE) return;
-    if (playerState[survivor] == PlayerState:HUNTER_GETUP) {
+    if (survivor != SC_NONE && playerState[survivor] != PlayerState:HUNTER_GETUP)
+	{
         interrupt[survivor] = true;
     }
 }
@@ -149,15 +149,17 @@ public smoker_land(Handle:event, const String:name[], bool:dontBroadcast) {
 public jockey_land(Handle:event, const String:name[], bool:dontBroadcast) {
     new client = GetClientOfUserId(GetEventInt(event, "victim"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor == SC_NONE) return;
-    playerState[survivor] = PlayerState:JOCKEYED;
+    if (survivor != SC_NONE)
+	{
+		playerState[survivor] = PlayerState:JOCKEYED;
+	}
 }
 
 public jockey_clear(Handle:event, const String:name[], bool:dontBroadcast) {
     new client = GetClientOfUserId(GetEventInt(event, "victim"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor == SC_NONE) return;
-    if (playerState[survivor] == PlayerState:JOCKEYED) {
+    if (survivor != SC_NONE && playerState[survivor] != PlayerState:JOCKEYED)
+	{
         playerState[survivor] = PlayerState:UPRIGHT;
     }
 }
@@ -166,82 +168,100 @@ public jockey_clear(Handle:event, const String:name[], bool:dontBroadcast) {
 public smoker_clear(Handle:event, const String:name[], bool:dontBroadcast) {
     new client = GetClientOfUserId(GetEventInt(event, "victim"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor == SC_NONE) return;
-    if (playerState[survivor] == PlayerState:INCAPPED) return;
-    playerState[survivor] = PlayerState:UPRIGHT;
-    _CancelGetup(client);
+    if (survivor != SC_NONE && playerState[survivor] != PlayerState:INCAPPED)
+	{
+		playerState[survivor] = PlayerState:UPRIGHT;
+		_CancelGetup(client);
+	}
 }
 
 // If a player is cleared from a hunter, they should have 1 getup.
-public hunter_clear(Handle:event, const String:name[], bool:dontBroadcast) {
+public hunter_clear(Handle:event, const String:name[], bool:dontBroadcast) 
+{
     new client = GetClientOfUserId(GetEventInt(event, "victim"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor == SC_NONE) return;
-    if (playerState[survivor] == PlayerState:INCAPPED) return;
-    // If someone gets cleared WHILE they are otherwise getting up, they double-getup.
-    if (isGettingUp(survivor)) {
-        pendingGetups[survivor]++;
-        return;
-    }
-    playerState[survivor] = PlayerState:HUNTER_GETUP;
-    _GetupTimer(client);
+    if (survivor != SC_NONE && playerState[survivor] != PlayerState:INCAPPED)
+	{
+		// If someone gets cleared WHILE they are otherwise getting up, they double-getup.
+		if (isGettingUp(survivor))
+		{
+			pendingGetups[survivor]++;
+		}
+		else
+		{
+			playerState[survivor] = PlayerState:HUNTER_GETUP;
+			_GetupTimer(client);
+		}
+	}
 }
 
 // If a player is impacted during a charged, they should have 1 getup.
-public multi_charge(Handle:event, const String:name[], bool:dontBroadcast) {
+public multi_charge(Handle:event, const String:name[], bool:dontBroadcast) 
+{
     new SurvivorCharacter:survivor = IdentifySurvivor(GetClientOfUserId(GetEventInt(event, "victim")));
-    if (survivor == SC_NONE) return;
-    if (playerState[survivor] == PlayerState:INCAPPED) return;
-    playerState[survivor] = PlayerState:MULTI_CHARGED;
+    if (survivor != SC_NONE && playerState[survivor] != PlayerState:INCAPPED)
+    {
+		playerState[survivor] = PlayerState:MULTI_CHARGED;
+	}
 }
 
 // If a player is cleared from a charger, they should have 1 getup.
 public charger_land_instant(Handle:event, const String:name[], bool:dontBroadcast) {
     new SurvivorCharacter:survivor = IdentifySurvivor(GetClientOfUserId(GetEventInt(event, "victim")));
-    if (survivor == SC_NONE) return;
-    // If the player is incapped when the charger lands, they will getup after being revived.
-    if (playerState[survivor] == PlayerState:INCAPPED) {
-        pendingGetups[survivor]++;
-    }
-    playerState[survivor] = PlayerState:INSTACHARGED;
+    if (survivor != SC_NONE)
+	{
+		// If the player is incapped when the charger lands, they will getup after being revived.
+		if (playerState[survivor] == PlayerState:INCAPPED) 
+		{
+			pendingGetups[survivor]++;
+		}
+		playerState[survivor] = PlayerState:INSTACHARGED;
+	}
 }
 
 // This event defines when a player transitions from being insta-charged to being pummeled.
-public charger_land(Handle:event, const String:name[], bool:dontBroadcast) {
+public charger_land(Handle:event, const String:name[], bool:dontBroadcast) 
+{
     new SurvivorCharacter:survivor = IdentifySurvivor(GetClientOfUserId(GetEventInt(event, "victim")));
-    if (survivor == SC_NONE) return;
-    if (playerState[survivor] == PlayerState:INCAPPED) return;
-    playerState[survivor] = PlayerState:CHARGED;
+    if (survivor != SC_NONE && playerState[survivor] != PlayerState:INCAPPED)
+	{
+		playerState[survivor] = PlayerState:CHARGED;
+	}
 }
 
 // If a player is cleared from a charger, they should have 1 getup.
 public charger_clear(Handle:event, const String:name[], bool:dontBroadcast) {
     new client = GetClientOfUserId(GetEventInt(event, "victim"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor == SC_NONE) return;
-    if (playerState[survivor] == PlayerState:INCAPPED) return;
-    playerState[survivor] = PlayerState:CHARGER_GETUP;
-    _GetupTimer(client);
+    if (survivor != SC_NONE && playerState[survivor] != PlayerState:INCAPPED)
+	{
+		playerState[survivor] = PlayerState:CHARGER_GETUP;
+		_GetupTimer(client);
+	}
 }
 
 // If a player is incapped, mark that down. This will interrupt their animations, if they have any.
 public player_incap(Handle:event, const String:name[], bool:dontBroadcast) {
     new SurvivorCharacter:survivor = IdentifySurvivor(GetClientOfUserId(GetEventInt(event, "userid")));
-    if (survivor == SC_NONE) return;
-    // If the player is incapped when the charger lands, they will getup after being revived.
-    if (playerState[survivor] == PlayerState:INSTACHARGED) {
-        pendingGetups[survivor]++;
-    }
-    playerState[survivor] = PlayerState:INCAPPED;
+    if (survivor != SC_NONE)
+	{
+		// If the player is incapped when the charger lands, they will getup after being revived.
+		if (playerState[survivor] == PlayerState:INSTACHARGED) {
+			pendingGetups[survivor]++;
+		}
+		playerState[survivor] = PlayerState:INCAPPED;
+	}
 }
 
 // When a player is picked up, they should have 0 getups.
 public player_revive(Handle:event, const String:name[], bool:dontBroadcast) {
     new client = GetClientOfUserId(GetEventInt(event, "subject"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor == SC_NONE) return;
-    playerState[survivor] = PlayerState:UPRIGHT;
-    _CancelGetup(client);
+    if (survivor != SC_NONE)
+	{
+		playerState[survivor] = PlayerState:UPRIGHT;
+		_CancelGetup(client);
+	}
 }
 
 // A catch-all to handle damage that is not associated with an event. I use this instead of player_hurt because it ignores godframes.

--- a/addons/sourcemod/scripting/double_getup.sp
+++ b/addons/sourcemod/scripting/double_getup.sp
@@ -168,7 +168,7 @@ public jockey_clear(Handle:event, const String:name[], bool:dontBroadcast) {
 public smoker_clear(Handle:event, const String:name[], bool:dontBroadcast) {
     new client = GetClientOfUserId(GetEventInt(event, "victim"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor != SC_NONE && playerState[survivor] == PlayerState:INCAPPED)
+    if (survivor != SC_NONE && playerState[survivor] != PlayerState:INCAPPED)
 	{
 		playerState[survivor] = PlayerState:UPRIGHT;
 		_CancelGetup(client);

--- a/addons/sourcemod/scripting/double_getup.sp
+++ b/addons/sourcemod/scripting/double_getup.sp
@@ -140,7 +140,7 @@ public round_start(Handle:event, const String:name[], bool:dontBroadcast) {
 public smoker_land(Handle:event, const String:name[], bool:dontBroadcast) {
     new client = GetClientOfUserId(GetEventInt(event, "victim"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor != SC_NONE && playerState[survivor] != PlayerState:HUNTER_GETUP)
+    if (survivor != SC_NONE && playerState[survivor] == PlayerState:HUNTER_GETUP)
 	{
         interrupt[survivor] = true;
     }
@@ -158,7 +158,7 @@ public jockey_land(Handle:event, const String:name[], bool:dontBroadcast) {
 public jockey_clear(Handle:event, const String:name[], bool:dontBroadcast) {
     new client = GetClientOfUserId(GetEventInt(event, "victim"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor != SC_NONE && playerState[survivor] != PlayerState:JOCKEYED)
+    if (survivor != SC_NONE && playerState[survivor] == PlayerState:JOCKEYED)
 	{
         playerState[survivor] = PlayerState:UPRIGHT;
     }
@@ -168,7 +168,7 @@ public jockey_clear(Handle:event, const String:name[], bool:dontBroadcast) {
 public smoker_clear(Handle:event, const String:name[], bool:dontBroadcast) {
     new client = GetClientOfUserId(GetEventInt(event, "victim"));
     new SurvivorCharacter:survivor = IdentifySurvivor(client);
-    if (survivor != SC_NONE && playerState[survivor] != PlayerState:INCAPPED)
+    if (survivor != SC_NONE && playerState[survivor] == PlayerState:INCAPPED)
 	{
 		playerState[survivor] = PlayerState:UPRIGHT;
 		_CancelGetup(client);

--- a/addons/sourcemod/scripting/l4d2_melee_fix.sp
+++ b/addons/sourcemod/scripting/l4d2_melee_fix.sp
@@ -32,30 +32,11 @@ public Action:PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast)
         //Testing showed that only the L4D1 SI; Hunter, Smoker and Boomer have issues with correct Melee Damage values being applied, check for Spitter and Jockey anyway!
         if(class <= 5 && health > 0)
         {
-			//Award damage to Attacker accordingly.
-            //SDKHooks_TakeDamage(victim, 0, attacker, float(health));
-            new Handle:hData = CreateDataPack();
-            WritePackCell(hData, victim);
-            WritePackCell(hData, attacker);
-            WritePackCell(hData, health);
-            RequestFrame(ApplyDamageFrameCallback, hData);
+            //Award damage to Attacker accordingly.
+            SDKHooks_TakeDamage(victim, 0, attacker, float(health));
         }    
     }
 }	
-
-public ApplyDamageFrameCallback(any:hData)
-{
-    ResetPack(hData, false);
-    new victim = ReadPackCell(hData);
-    new attacker = ReadPackCell(hData);
-    new health = ReadPackCell(hData);
-    CloseHandle(hData);
-    if (IsClientInGame(victim) && IsPlayerAlive(victim) && IsClientInGame(attacker))
-    {
-        SDKHooks_TakeDamage(victim, 0, attacker, float(health));
-    }
-}
- 
 
 bool:IsSi(client) 
 {

--- a/addons/sourcemod/scripting/l4d2_melee_fix.sp
+++ b/addons/sourcemod/scripting/l4d2_melee_fix.sp
@@ -32,11 +32,30 @@ public Action:PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast)
         //Testing showed that only the L4D1 SI; Hunter, Smoker and Boomer have issues with correct Melee Damage values being applied, check for Spitter and Jockey anyway!
         if(class <= 5 && health > 0)
         {
-            //Award damage to Attacker accordingly.
-            SDKHooks_TakeDamage(victim, 0, attacker, float(health));
+			//Award damage to Attacker accordingly.
+            //SDKHooks_TakeDamage(victim, 0, attacker, float(health));
+            new Handle:hData = CreateDataPack();
+            WritePackCell(hData, victim);
+            WritePackCell(hData, attacker);
+            WritePackCell(hData, health);
+            RequestFrame(ApplyDamageFrameCallback, hData);
         }    
     }
 }	
+
+public ApplyDamageFrameCallback(any:hData)
+{
+    ResetPack(hData, false);
+    new victim = ReadPackCell(hData);
+    new attacker = ReadPackCell(hData);
+    new health = ReadPackCell(hData);
+    CloseHandle(hData);
+    if (IsClientInGame(victim) && IsPlayerAlive(victim) && IsClientInGame(attacker))
+    {
+        SDKHooks_TakeDamage(victim, 0, attacker, float(health));
+    }
+}
+ 
 
 bool:IsSi(client) 
 {

--- a/addons/sourcemod/scripting/l4d2_melee_fix.sp
+++ b/addons/sourcemod/scripting/l4d2_melee_fix.sp
@@ -33,7 +33,6 @@ public Action:PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast)
         if(class <= 5 && health > 0)
         {
 			//Award damage to Attacker accordingly.
-            //SDKHooks_TakeDamage(victim, 0, attacker, float(health));
             new Handle:hData = CreateDataPack();
             WritePackCell(hData, victim);
             WritePackCell(hData, attacker);
@@ -55,7 +54,6 @@ public ApplyDamageFrameCallback(any:hData)
         SDKHooks_TakeDamage(victim, 0, attacker, float(health));
     }
 }
- 
 
 bool:IsSi(client) 
 {


### PR DESCRIPTION
1. fully fix crash in plugin l4d2_melee_fix on SM 1.7 (thx sheo), in theory apply damage via SDKHooks_TakeDamage in event **player_hurt** in same frame with event was do crash in some situations.
2. add version double_getup with no return logic.